### PR TITLE
Generate URL for radar image

### DIFF
--- a/radar_api_app/app.py
+++ b/radar_api_app/app.py
@@ -16,5 +16,11 @@ def service(module):
     except ValueError:
         return 'Module not found', 404
 
+
+@app.route('/service/radar/<path:filename>', methods=['GET'])
+def get_radar_image(filename):
+    """Serve radar images stored in the application."""
+    return main.get_image(filename)
+
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000, debug=True)

--- a/radar_api_app/main.py
+++ b/radar_api_app/main.py
@@ -2,19 +2,22 @@
 import os
 from flask import current_app, send_from_directory, abort
 
-def service(module):
-    """
-    Devuelve siempre descarga.png que está en <tu_app>/images.
-    El parámetro 'module' lo ignoras por ahora.
-    """
-    images_dir = os.path.join(current_app.root_path, 'images')
 
+def get_image(filename):
+    """Return an image file from the images directory."""
+    images_dir = os.path.join(current_app.root_path, 'images')
     try:
         return send_from_directory(
             images_dir,
-            "descarga.png",
-            as_attachment=False,        # True = fuerza descarga; False = la muestra inline
-            cache_timeout=31536000      # 1 año de caché si lo necesitas
+            filename,
+            as_attachment=False,
+            cache_timeout=31536000
         )
     except FileNotFoundError:
         abort(404)
+
+def service(module):
+    """Return a URL where the generated image can be accessed."""
+    filename = "descarga.png"
+    url = f"http://46.202.177.37/service/radar/{filename}"
+    return url


### PR DESCRIPTION
## Summary
- change main service to return a URL pointing to the generated image
- expose `/service/radar/<filename>` endpoint to serve stored radar images

## Testing
- `pytest -q`